### PR TITLE
Restore nop()

### DIFF
--- a/step1/include/zhpeq_util.h
+++ b/step1/include/zhpeq_util.h
@@ -276,6 +276,11 @@ static inline void io_mb(void)
 
 #define L1_CACHE_BYTES  (64UL)
 
+static inline void nop(void)
+{
+    asm volatile("nop");
+}
+
 #endif
 
 #ifndef _BARRIER_DEFINED


### PR DESCRIPTION
When we build with carbon stats, libzhpe_stats.c needs nop(), which used to be in zhpeq_util.h
Signed-off-by: Harumi Kuno <harumi.kuno@hpe.com>